### PR TITLE
added fromStream and basic test for fromStream

### DIFF
--- a/lib/src/df.dart
+++ b/lib/src/df.dart
@@ -165,7 +165,7 @@ class DataFrame {
       bool verbose = false}) async {
     final file = File(path);
     if (!file.existsSync()) {
-      throw FileNotFoundException("File not found: $path");
+      throw FileNotFoundException('File not found: $path');
     }
 
     return fromStream(

--- a/lib/src/df.dart
+++ b/lib/src/df.dart
@@ -113,24 +113,16 @@ class DataFrame {
     return colValues;
   }
 
-  /// Build a dataframe from a csv file
-  static Future<DataFrame> fromCsv(String path,
+  /// Build a dataframe from a utf8 encoded stream of comma separated strings
+  static Future<DataFrame> fromStream(Stream<String> stream,
       {String dateFormat,
-      String timestampCol,
-      TimestampFormat timestampFormat = TimestampFormat.milliseconds,
-      bool verbose = false}) async {
-    final file = File(path);
-    if (!file.existsSync()) {
-      throw FileNotFoundException("File not found: $path");
-    }
+        String timestampCol,
+        TimestampFormat timestampFormat = TimestampFormat.milliseconds,
+        bool verbose = false}) async {
     final df = DataFrame();
     var i = 1;
     List<String> _colNames;
-    await file
-        .openRead()
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
-        .forEach((line) {
+    await stream.forEach((line) {
       //print('line $i: $line');
       final vals = line.split(",");
       if (i == 1) {
@@ -163,6 +155,29 @@ class DataFrame {
       print("Parsed ${df._matrix.data.length} rows");
     }
     return df;
+  }
+
+  /// Build a dataframe from a csv file
+  static Future<DataFrame> fromCsv(String path,
+      {String dateFormat,
+      String timestampCol,
+      TimestampFormat timestampFormat = TimestampFormat.milliseconds,
+      bool verbose = false}) async {
+    final file = File(path);
+    if (!file.existsSync()) {
+      throw FileNotFoundException("File not found: $path");
+    }
+
+    return fromStream(
+      file
+        .openRead()
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter()),
+      dateFormat: dateFormat,
+      timestampCol: timestampCol,
+      timestampFormat: timestampFormat,
+      verbose: verbose,
+    );
   }
 
   DataFrame._copyWithMatrix(DataFrame df, List<List<dynamic>> matrix) {

--- a/test/df_test.dart
+++ b/test/df_test.dart
@@ -85,13 +85,6 @@ void main() {
       expect(e.runtimeType.toString() == "FileNotFoundException", true);
       expect(e.message, 'File not found: /wrong/path');
     });
-
-    df = await DataFrame.fromCsv("test/data/data_timestamp_s.csv",
-        timestampCol: "timestamp",
-        timestampFormat: TimestampFormat.seconds,
-        verbose: true)
-      ..show();
-    expect(df.columnsNames, <String>["symbol", "price", "n", "timestamp"]);
   });
 
   test("subset", () async {

--- a/test/df_test.dart
+++ b/test/df_test.dart
@@ -85,6 +85,13 @@ void main() {
       expect(e.runtimeType.toString() == "FileNotFoundException", true);
       expect(e.message, 'File not found: /wrong/path');
     });
+
+    df = await DataFrame.fromCsv("test/data/data_timestamp_s.csv",
+        timestampCol: "timestamp",
+        timestampFormat: TimestampFormat.seconds,
+        verbose: true)
+      ..show();
+    expect(df.columnsNames, <String>["symbol", "price", "n", "timestamp"]);
   });
 
   test("subset", () async {
@@ -244,6 +251,16 @@ void main() {
     ];
     edf.dataset = dataset;
     expect(edf.dataset, dataset);
+  });
+
+  test("from stream", () async {
+    final inputStream = Stream<String>.fromIterable([
+      "a,b",
+      "1,2"
+    ]);
+    df = await DataFrame.fromStream(inputStream);
+    expect(df.columnsNames, ["a","b"]);
+    expect(df.rows.toList(), [{"a": 1, "b": 2}]);
   });
 }
 

--- a/test/df_test.dart
+++ b/test/df_test.dart
@@ -246,14 +246,13 @@ void main() {
     expect(edf.dataset, dataset);
   });
 
-  test("from stream", () async {
-    final inputStream = Stream<String>.fromIterable([
-      "a,b",
-      "1,2"
-    ]);
+  test('from stream', () async {
+    final inputStream = Stream<String>.fromIterable(['a,b', '1,2']);
     df = await DataFrame.fromStream(inputStream);
-    expect(df.columnsNames, ["a","b"]);
-    expect(df.rows.toList(), [{"a": 1, "b": 2}]);
+    expect(df.columnsNames, ['a', 'b']);
+    expect(df.rows.toList(), [
+      {'a': 1, 'b': 2}
+    ]);
   });
 }
 


### PR DESCRIPTION
Adds a 'fromStream' method to DataFrame along with a basic test for fromStream. Refactors fromCSV to rely on fromStream to avoid code duplication. Changes should be non-breaking.

Useful for writing tests that rely on parsing logic without having to construct a .csv (I'm about to add support for properly respecting escape quotes and would like to write tests without having to create a new csv for each one).

Could  also be valuable to some users whose input data is coming from somewhere other than a file (eg a network connection).

