### PR TITLE
switch to single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A dataframe for Dart
 From csv:
 
    ```dart
-   final df = await DataFrame.fromCsv("dataset/stocks.csv");
+   final df = await DataFrame.fromCsv('dataset/stocks.csv');
    ```
 
 Note: the type of the records are infered from the data. The first line of the csv must contains the headers for the column names. Optional parameters:
@@ -28,8 +28,8 @@ From records:
 
    ```dart
    final rows = <Map<String, dynamic>> rows[
-      <String, dynamic>{"col1": 21, "col2": "foo", "col3": DateTime.now()},
-      <String, dynamic>{"col1": 22, "col2": "bar", "col3": DateTime.now()},
+      <String, dynamic>{'col1': 21, 'col2': 'foo', 'col3': DateTime.now()},
+      <String, dynamic>{'col1': 22, 'col2': 'bar', 'col3': DateTime.now()},
    ];
    final df = DataFrame.fromRows(rows);
    ```
@@ -41,7 +41,7 @@ From records:
    // select a subset of rows
    final List<Map<String, dynamic>> rows = df.subset(0,100);
    /// select records for a column
-   final List<double> values = df.colRecords<double>("col2");
+   final List<double> values = df.colRecords<double>('col2');
    /// select list of records
    final List<List<dynamic>> records = df.records;
    ```
@@ -52,7 +52,7 @@ Add data:
 
    ```dart
    // add a row
-   df.addRow(<String,dynamic>{"col1": 1, "col2": 2.0});
+   df.addRow(<String,dynamic>{'col1': 1, 'col2': 2.0});
    // add a line of records
    df.addRecord(<dynamic>[1, 2.0]);
    ```
@@ -82,17 +82,17 @@ Copy a dataframe:
 Nulls and zeros:
 
    ```dart
-   final int n = df.countNulls_("col1");
-   final int n = df.countZeros_("col1");
+   final int n = df.countNulls_('col1');
+   final int n = df.countZeros_('col1');
    ```
 
 Columns:
 
    ```dart
-   final int mean = df.mean("col1");
-   final int sum = df.sum("col1");
-   final int max = df.max("col1");
-   final int min = df.min("col1");
+   final int mean = df.mean('col1');
+   final int sum = df.sum('col1');
+   final int max = df.max('col1');
+   final int min = df.min('col1');
    ```
 
 ### Info

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,8 +1,8 @@
 import 'package:df/df.dart';
 
 Future<void> main() async {
-  final df = await DataFrame.fromCsv("dataset/stocks.csv",
-      dateFormat: "MMM dd yyyy", verbose: true);
+  final df = await DataFrame.fromCsv('dataset/stocks.csv',
+      dateFormat: 'MMM dd yyyy', verbose: true);
   df.show();
   print(df.columns);
 }

--- a/lib/src/column.dart
+++ b/lib/src/column.dart
@@ -40,7 +40,7 @@ class DataFrameColumn {
 
   @override
   String toString() {
-    return "$name ($type)";
+    return '$name ($type)';
   }
 
   @override

--- a/lib/src/df.dart
+++ b/lib/src/df.dart
@@ -121,7 +121,7 @@ class DataFrame {
       bool verbose = false}) async {
     final file = File(path);
     if (!file.existsSync()) {
-      throw FileNotFoundException("File not found: $path");
+      throw FileNotFoundException('File not found: $path');
     }
     final df = DataFrame();
     var i = 1;
@@ -132,7 +132,7 @@ class DataFrame {
         .transform<String>(const LineSplitter())
         .forEach((line) {
       //print('line $i: $line');
-      final vals = line.split(",");
+      final vals = line.split(',');
       if (i == 1) {
         // set columns names
         _colNames = vals;
@@ -160,7 +160,7 @@ class DataFrame {
       ++i;
     });
     if (verbose) {
-      print("Parsed ${df._matrix.data.length} rows");
+      print('Parsed ${df._matrix.data.length} rows');
     }
     return df;
   }
@@ -232,10 +232,10 @@ class DataFrame {
   int countNulls_(String colName,
       {List<dynamic> nullValues = const <dynamic>[
         null,
-        "null",
-        "nan",
-        "NULL",
-        "N/A"
+        'null',
+        'nan',
+        'NULL',
+        'N/A'
       ]}) {
     final n = _matrix.countForValues(_indiceForColumn(colName), nullValues);
     return n;
@@ -307,13 +307,13 @@ class DataFrame {
     }
     final rows = _matrix.data.sublist(0, l);
     _info.printRows(rows);
-    print("$length rows");
+    print('$length rows');
   }
 
   /// Print info and sample data
   void show([int lines = 5]) {
     print(
-        "${_columns.length} columns and $length rows: ${columnsNames.join(", ")}");
+        '${_columns.length} columns and $length rows: ${columnsNames.join(', ')}');
     var l = lines;
     if (length < lines) {
       l = length;
@@ -389,7 +389,7 @@ class DataFrame {
       ++i;
     }
     if (ind == null) {
-      throw ColumnNotFoundException("Can not find column $colName");
+      throw ColumnNotFoundException('Can not find column $colName');
     }
     return ind;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
-  meta: ^1.1.8
-  pedantic: ^1.8.0
   extra_pedantic: ^1.1.1+3
-  ml_linalg: ^12.7.1
   jiffy: ^3.0.1
+  meta: ^1.1.8
+  ml_linalg: ^12.7.1
+  pedantic: ^1.8.0
 
 dev_dependencies:
   test: ^1.6.5

--- a/test/df_test.dart
+++ b/test/df_test.dart
@@ -1,4 +1,4 @@
-import "package:test/test.dart";
+import 'package:test/test.dart';
 import 'package:df/df.dart';
 
 DataFrame baseDf;
@@ -6,27 +6,27 @@ DataFrame baseDf;
 void main() {
   DataFrame df;
 
-  test("from rows", () async {
+  test('from rows', () async {
     final date = DateTime.now();
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": "a", "col2": 1, "col3": 1.0, "col4": date},
-      <String, dynamic>{"col1": "b", "col2": 2, "col3": 2.0, "col4": date},
+      <String, dynamic>{'col1': 'a', 'col2': 1, 'col3': 1.0, 'col4': date},
+      <String, dynamic>{'col1': 'b', 'col2': 2, 'col3': 2.0, 'col4': date},
     ];
     df = DataFrame.fromRows(rows);
     expect(df.length, 2);
-    expect(df.columnsNames, <String>["col1", "col2", "col3", "col4"]);
+    expect(df.columnsNames, <String>['col1', 'col2', 'col3', 'col4']);
     expect(df.rows, rows);
     expect(df.dataset, <dynamic>[
-      <dynamic>["a", 1, 1.0, date],
-      <dynamic>["b", 2, 2.0, date]
+      <dynamic>['a', 1, 1.0, date],
+      <dynamic>['b', 2, 2.0, date]
     ]);
-    expect(df.colRecords<String>("col1"), <String>["a", "b"]);
-    expect(df.colRecords<String>("col1", limit: 1), <String>["a"]);
+    expect(df.colRecords<String>('col1'), <String>['a', 'b']);
+    expect(df.colRecords<String>('col1', limit: 1), <String>['a']);
     final cols = <DataFrameColumn>[
-      DataFrameColumn(name: "col1", type: String),
-      DataFrameColumn(name: "col2", type: int),
-      DataFrameColumn(name: "col3", type: double),
-      DataFrameColumn(name: "col4", type: DateTime),
+      DataFrameColumn(name: 'col1', type: String),
+      DataFrameColumn(name: 'col2', type: int),
+      DataFrameColumn(name: 'col3', type: double),
+      DataFrameColumn(name: 'col4', type: DateTime),
     ];
     expect(df.columns, cols);
     // errors
@@ -42,60 +42,60 @@ void main() {
     }
   });
 
-  test("csv", () async {
+  test('csv', () async {
     // date
-    df = await DataFrame.fromCsv("test/data/data_date.csv",
-        dateFormat: "MMM dd yyyy", verbose: true)
+    df = await DataFrame.fromCsv('test/data/data_date.csv',
+        dateFormat: 'MMM dd yyyy', verbose: true)
       ..show();
     expect(df.length, 2);
-    expect(df.columnsNames, <String>["symbol", "date", "price", "n"]);
+    expect(df.columnsNames, <String>['symbol', 'date', 'price', 'n']);
 
     // date iso
-    df = await DataFrame.fromCsv("test/data/data_date_iso.csv", verbose: true)
+    df = await DataFrame.fromCsv('test/data/data_date_iso.csv', verbose: true)
       ..show();
     expect(df.length, 2);
-    expect(df.columnsNames, <String>["symbol", "date", "price", "n"]);
+    expect(df.columnsNames, <String>['symbol', 'date', 'price', 'n']);
 
     // timestamp
-    df = await DataFrame.fromCsv("test/data/data_timestamp_ms.csv",
-        timestampCol: "timestamp", verbose: true)
+    df = await DataFrame.fromCsv('test/data/data_timestamp_ms.csv',
+        timestampCol: 'timestamp', verbose: true)
       ..show();
-    expect(df.columnsNames, <String>["symbol", "price", "n", "timestamp"]);
+    expect(df.columnsNames, <String>['symbol', 'price', 'n', 'timestamp']);
 
     // timestamp microseconds
-    df = await DataFrame.fromCsv("test/data/data_timestamp_mi.csv",
-        timestampCol: "timestamp",
+    df = await DataFrame.fromCsv('test/data/data_timestamp_mi.csv',
+        timestampCol: 'timestamp',
         timestampFormat: TimestampFormat.microseconds,
         verbose: true)
       ..show();
-    expect(df.columnsNames, <String>["symbol", "price", "n", "timestamp"]);
+    expect(df.columnsNames, <String>['symbol', 'price', 'n', 'timestamp']);
 
     // timestamp seconds
-    df = await DataFrame.fromCsv("test/data/data_timestamp_s.csv",
-        timestampCol: "timestamp",
+    df = await DataFrame.fromCsv('test/data/data_timestamp_s.csv',
+        timestampCol: 'timestamp',
         timestampFormat: TimestampFormat.seconds,
         verbose: true)
       ..show();
-    expect(df.columnsNames, <String>["symbol", "price", "n", "timestamp"]);
+    expect(df.columnsNames, <String>['symbol', 'price', 'n', 'timestamp']);
 
     final df2 = df.copy_();
     expect(df2.length, df.length);
 
-    df = await DataFrame.fromCsv("/wrong/path").catchError((dynamic e) {
-      expect(e.runtimeType.toString() == "FileNotFoundException", true);
+    df = await DataFrame.fromCsv('/wrong/path').catchError((dynamic e) {
+      expect(e.runtimeType.toString() == 'FileNotFoundException', true);
       expect(e.message, 'File not found: /wrong/path');
     });
   });
 
-  test("subset", () async {
-    baseDf = await DataFrame.fromCsv("example/dataset/stocks.csv");
+  test('subset', () async {
+    baseDf = await DataFrame.fromCsv('example/dataset/stocks.csv');
     df = baseDf..subset(0, 30);
     expect(df.length, 30);
     final df2 = df.subset_(0, 30);
     expect(df2.length, 30);
   });
 
-  test("limit", () async {
+  test('limit', () async {
     df = baseDf..limit(30);
     expect(df.length, 30);
     final df2 = df.limit_(30);
@@ -108,25 +108,25 @@ void main() {
     expect(df.length, 20);
   });
 
-  test("count", () async {
+  test('count', () async {
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": 0, "col2": "b"},
-      <String, dynamic>{"col1": 1, "col2": null},
+      <String, dynamic>{'col1': 0, 'col2': 'b'},
+      <String, dynamic>{'col1': 1, 'col2': null},
     ];
     df = DataFrame.fromRows(rows)..show();
-    final z = df.countZeros_("col1");
+    final z = df.countZeros_('col1');
     expect(z, 1);
-    final n = df.countNulls_("col2");
+    final n = df.countNulls_('col2');
     expect(n, 1);
   });
 
-  test("mutate", () async {
+  test('mutate', () async {
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": 0, "col2": 4},
-      <String, dynamic>{"col1": 1, "col2": 2},
+      <String, dynamic>{'col1': 0, 'col2': 4},
+      <String, dynamic>{'col1': 1, 'col2': 2},
     ];
     df = DataFrame.fromRows(rows)
-      ..addRow(<String, dynamic>{"col1": 4, "col2": 2});
+      ..addRow(<String, dynamic>{'col1': 4, 'col2': 2});
     expect(df.length, 3);
     df.removeRowAt(2);
     expect(df.rows, rows);
@@ -142,62 +142,62 @@ void main() {
     expect(df.length, 3);
   });
 
-  test("calc", () async {
+  test('calc', () async {
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": 1, "col2": 2},
-      <String, dynamic>{"col1": 1, "col2": 1},
+      <String, dynamic>{'col1': 1, 'col2': 2},
+      <String, dynamic>{'col1': 1, 'col2': 1},
     ];
     df = DataFrame.fromRows(rows)..head();
-    expect(df.max_("col2"), 2);
-    expect(df.min_("col2"), 1);
-    expect(df.mean_("col1"), 1);
-    expect(df.sum_("col1"), 2);
+    expect(df.max_('col2'), 2);
+    expect(df.min_('col2'), 1);
+    expect(df.mean_('col1'), 1);
+    expect(df.sum_('col1'), 2);
   });
 
-  test("error", () async {
+  test('error', () async {
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": 1, "col2": 2},
-      <String, dynamic>{"col1": 1, "col2": 1},
+      <String, dynamic>{'col1': 1, 'col2': 2},
+      <String, dynamic>{'col1': 1, 'col2': 1},
     ];
     df = DataFrame.fromRows(rows)..cols();
     try {
-      df.sum_("wrong_col");
+      df.sum_('wrong_col');
     } catch (e) {
       expect(e is ColumnNotFoundException, true);
     }
     try {
-      df.colRecords<double>("col1");
+      df.colRecords<double>('col1');
     } catch (e) {
       expect(e.toString(),
-          "type 'int' is not a subtype of type 'double' in type cast");
+          'type \'int\' is not a subtype of type \'double\' in type cast');
     }
     try {
-      DataFrameColumn.inferFromRecord("1", null);
+      DataFrameColumn.inferFromRecord('1', null);
     } catch (e) {
       expect(e is AssertionError, true);
     }
     try {
-      DataFrameColumn.inferFromRecord(null, "n");
+      DataFrameColumn.inferFromRecord(null, 'n');
     } catch (e) {
       expect(e is AssertionError, true);
     }
   });
 
-  test("sort", () async {
+  test('sort', () async {
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": 1, "col2": 4},
-      <String, dynamic>{"col1": 2, "col2": 3},
-      <String, dynamic>{"col1": 3, "col2": 2},
-      <String, dynamic>{"col1": 4, "col2": 1},
+      <String, dynamic>{'col1': 1, 'col2': 4},
+      <String, dynamic>{'col1': 2, 'col2': 3},
+      <String, dynamic>{'col1': 3, 'col2': 2},
+      <String, dynamic>{'col1': 4, 'col2': 1},
     ];
     df = DataFrame.fromRows(rows)
       ..head()
-      ..sort("col2");
-    expect(df.colRecords<int>("col1"), <int>[4, 3, 2, 1]);
-    final df2 = df.sort_("col1");
-    expect(df2.colRecords<int>("col1"), <int>[1, 2, 3, 4]);
+      ..sort('col2');
+    expect(df.colRecords<int>('col1'), <int>[4, 3, 2, 1]);
+    final df2 = df.sort_('col1');
+    expect(df2.colRecords<int>('col1'), <int>[1, 2, 3, 4]);
     try {
-      df.sort_("wrong_col");
+      df.sort_('wrong_col');
     } catch (e) {
       expect(e is ColumnNotFoundException, true);
     }
@@ -208,33 +208,33 @@ void main() {
     }
   });
 
-  test("column", () async {
+  test('column', () async {
     final rows = <Map<String, dynamic>>[
-      <String, dynamic>{"col1": 1, "col2": 2},
-      <String, dynamic>{"col1": 1, "col2": 1},
+      <String, dynamic>{'col1': 1, 'col2': 2},
+      <String, dynamic>{'col1': 1, 'col2': 1},
     ];
     df = DataFrame.fromRows(rows)..head();
     final h = df.columns[0].hashCode;
-    expect(h, "col1".hashCode);
-    expect(df.columnsIndices, <int, String>{0: "col1", 1: "col2"});
-    expect(df.columnIndice("col1"), 0);
+    expect(h, 'col1'.hashCode);
+    expect(df.columnsIndices, <int, String>{0: 'col1', 1: 'col2'});
+    expect(df.columnIndice('col1'), 0);
   });
 
-  test("type inference", () async {
-    var r = DataFrameColumn.inferFromRecord("0", "record");
+  test('type inference', () async {
+    var r = DataFrameColumn.inferFromRecord('0', 'record');
     expect(r.type, int);
-    r = DataFrameColumn.inferFromRecord("foo", "record");
+    r = DataFrameColumn.inferFromRecord('foo', 'record');
     expect(r.type, String);
     r = DataFrameColumn.inferFromRecord(
-        DateTime.now().toIso8601String(), "record");
+        DateTime.now().toIso8601String(), 'record');
     expect(r.type, DateTime);
   });
 
-  test("set", () async {
+  test('set', () async {
     final edf = ExtendedDf();
     final columns = <DataFrameColumn>[
-      DataFrameColumn(name: "col1", type: int),
-      DataFrameColumn(name: "col2", type: double),
+      DataFrameColumn(name: 'col1', type: int),
+      DataFrameColumn(name: 'col2', type: double),
     ];
     edf.setColumns(columns);
     expect(edf.columns, columns);


### PR DESCRIPTION
Switches the code base (with the exception of pubsec.yaml) over to single tick quotes. Should be non-breaking.

Single quotes are more conventional than double quotes and will make #6 much cleaner as it relies heavily on checking strings for the `"` character. CC @synw 